### PR TITLE
Do not let assembly reflection issues stop the process

### DIFF
--- a/AutoAutoMapper/AutoProfiler.cs
+++ b/AutoAutoMapper/AutoProfiler.cs
@@ -96,12 +96,19 @@ namespace AutoAutoMapper
 
         private static IEnumerable<Type> GetProfileClassesFrom(Assembly assembly)
         {
-            return assembly.GetTypes()
-                .Where(t =>
-                    t != typeof (Profile)
-                    && typeof (Profile).IsAssignableFrom(t)
-                    && !t.IsAbstract
-                );
+            try
+            {
+                return assembly.GetTypes()
+                    .Where(t =>
+                        t != typeof (Profile)
+                        && typeof (Profile).IsAssignableFrom(t)
+                        && !t.IsAbstract
+                    );
+            }
+            catch
+            {
+                return new Type[] {};
+            }
         }
     }
 }

--- a/AutoAutoMapper/AutoProfiler.cs
+++ b/AutoAutoMapper/AutoProfiler.cs
@@ -90,20 +90,18 @@ namespace AutoAutoMapper
         private static void GetConfiguration(IConfiguration configuration, IEnumerable<Assembly> assemblies)
         {
             foreach (var assembly in assemblies)
-            {
-                var profileClasses = assembly.GetTypes()
-                    .Where(t =>
-                        t != typeof(Profile)
-                        && typeof(Profile).IsAssignableFrom(t)
-                        && !t.IsAbstract
-                    )
-                    .ToArray()
-                ;
-                foreach (var profileClass in profileClasses)
-                {
+                foreach (var profileClass in GetProfileClassesFrom(assembly))
                     configuration.AddProfile((Profile)Activator.CreateInstance(profileClass));
-                }
-            }
+        }
+
+        private static IEnumerable<Type> GetProfileClassesFrom(Assembly assembly)
+        {
+            return assembly.GetTypes()
+                .Where(t =>
+                    t != typeof (Profile)
+                    && typeof (Profile).IsAssignableFrom(t)
+                    && !t.IsAbstract
+                );
         }
     }
 }


### PR DESCRIPTION
We had an issue loading an app due to some weird dll issue.  Not sure what it was, but something bad was in /bin, and reflecting over the assembly threw an error.

So this had nothing to do with AutoAutoMapper, but that's where the error appeared.  

I've had this happen before -- calling `GetTypes()` throws on some assembly for some reason, and it throws when I start the app because I love the idea of reflecting over the available assemblies to load up whatever's there.  So now when I do that, I like to isolate the retrieval of the types from an assembly in a try/catch.

Here's an example of the error:

```
[ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.]
   System.Reflection.RuntimeModule.GetTypes(RuntimeModule module) +0
   System.Reflection.RuntimeModule.GetTypes() +4
   System.Reflection.Assembly.GetTypes() +70
   AutoAutoMapper.AutoProfiler.GetConfiguration(IConfiguration configuration, IEnumerable`1 assemblies) +74
   AutoAutoMapper.<>c__DisplayClass1.<RegisterProfiles>b__0(IConfiguration configuration) +59
   AutoMapper.Mapper.Initialize(Action`1 action) +41
   AutoAutoMapper.AutoProfiler.RegisterProfiles(IEnumerable`1 assemblies) +60
   AutoAutoMapper.AutoProfiler.RegisterProfiles(Assembly[] assemblies) +28
   MyAppNamespace.AutoMapperConfig.RegisterProfiles() in c:\Builds\15\Source\App\Sources\App\trunk\src\App.Site\App_Start\AutoMapperConfig.cs:28
   App.Site.MvcApplication.Application_Start() in c:\Builds\15\Source\App\Sources\App\trunk\src\App\Global.asax.cs:32

```
